### PR TITLE
CSK-209 fix set a message

### DIFF
--- a/tangem-sdk-core/src/main/java/com/tangem/common/core/CardSession.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/common/core/CardSession.kt
@@ -136,6 +136,7 @@ class CardSession(
 
         scope.launch {
             reader.tag.asFlow()
+                    .drop(1)
                     .collect {
                         if (it == null) {
                             viewDelegate.onTagLost()


### PR DESCRIPTION
prevent handling the first nullable nfcTag for viewDelegate because it doesn't make sense and also triggers a race condition between onStartSession and new state tagLost() which handling by UI handler