### PR TITLE
CSK-235 fixed personalization if the NDEF entry is empty

### DIFF
--- a/tangem-sdk-core/src/main/java/com/tangem/common/deserialization/CardDeserializer.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/common/deserialization/CardDeserializer.kt
@@ -62,7 +62,7 @@ class CardDeserializer {
             )
             val issuer = Card.Issuer(
                     cardDataDecoder.decode(TlvTag.IssuerName),
-                    decoder.decode(TlvTag.IssuerDataPublicKey),
+                    decoder.decode(TlvTag.IssuerPublicKey),
             )
 
             val terminalStatus = if (decoder.decode(TlvTag.TerminalIsLinked)) {
@@ -128,7 +128,7 @@ class CardDeserializer {
                 decoder.decodeOptional<Int>(TlvTag.PauseBeforePin2)?.let { it * 10 } ?: 0,
                 decoder.decodeOptional(TlvTag.WalletsCount) ?: 1,
                 mask,
-                decoder.decode(TlvTag.SigningMethod),
+                decoder.decodeOptional(TlvTag.SigningMethod),
                 defaultCurve,
         )
     }

--- a/tangem-sdk-core/src/main/java/com/tangem/common/tlv/TlvTag.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/common/tlv/TlvTag.kt
@@ -66,7 +66,7 @@ enum class TlvTag(val code: Int) {
     ManufacturerName(0x20),
     CardIDManufacturerSignature(0x86),
 
-    IssuerDataPublicKey(0x30),
+    IssuerPublicKey(0x30),
     IssuerTransactionPublicKey(0x31),
     IssuerData(0x32),
     IssuerDataSignature(0x33),

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/PersonalizeCommand.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/PersonalizeCommand.kt
@@ -104,7 +104,7 @@ class PersonalizeCommand(
         tlvBuilder.append(TlvTag.NewPin2, config.pin2Sha256())
         tlvBuilder.append(TlvTag.NewPin3, config.pin3Sha256())
         tlvBuilder.append(TlvTag.CrExKey, config.hexCrExKey)
-        tlvBuilder.append(TlvTag.IssuerDataPublicKey, issuer.dataKeyPair.publicKey)
+        tlvBuilder.append(TlvTag.IssuerPublicKey, issuer.dataKeyPair.publicKey)
         tlvBuilder.append(TlvTag.IssuerTransactionPublicKey, issuer.transactionKeyPair.publicKey)
         tlvBuilder.append(TlvTag.AcquirerPublicKey, acquirer?.keyPair?.publicKey)
         tlvBuilder.append(TlvTag.CardData, serializeCardData(cardData, cardId))
@@ -112,9 +112,9 @@ class PersonalizeCommand(
         return tlvBuilder.serialize()
     }
 
-    private fun serializeNdef(config: CardConfig): ByteArray? {
-        return if (config.ndefRecords.isNullOrEmpty()) {
-            null
+    private fun serializeNdef(config: CardConfig): ByteArray {
+        return if (config.ndefRecords.isEmpty()) {
+            ByteArray(0)
         } else {
             NdefEncoder(config.ndefRecords, config.useDynamicNDEF == true).encode()
         }

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/entities/CardConfig.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/entities/CardConfig.kt
@@ -153,9 +153,8 @@ data class CardConfig(
 internal fun CardConfig.createSettingsMask(): Card.SettingsMask {
     val builder = MaskBuilder()
 
-    //Now we can personalize only reusable wallets
-    builder.add(Card.SettingsMask.Code.IsReusable)
-
+    val isReusable = isReusable ?: true
+    builder.addIf(isReusable, Card.SettingsMask.Code.IsReusable)
     builder.addIf(allowSetPIN1, Card.SettingsMask.Code.AllowSetPIN1)
     builder.addIf(allowSetPIN2, Card.SettingsMask.Code.AllowSetPIN2)
     builder.addIf(useCvc, Card.SettingsMask.Code.UseCvc)


### PR DESCRIPTION
- fixed personalization if the NDEF entry in the personalization config is empty.
- fixed cardSettings deserialization
- added isReusable field to the CardConfig