### PR TITLE
AND-2826 refactoring: restore supporting cross platform projects

### DIFF
--- a/tangem-sdk-android-demo/src/main/java/com/tangem/tangem_demo/DemoActivity.kt
+++ b/tangem-sdk-android-demo/src/main/java/com/tangem/tangem_demo/DemoActivity.kt
@@ -55,7 +55,6 @@ class DemoActivity : AppCompatActivity() {
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = fragmentPages[position].simpleName.replace("Fragment", "")
         }.attach()
-
     }
 
     fun listenPageChanges(callback: (Int) -> Unit) {
@@ -83,9 +82,9 @@ class DemoActivity : AppCompatActivity() {
         return TangemSdk(
             reader = nfcManager.reader,
             viewDelegate = viewDelegate,
-            biometricManager = authManager,
             secureStorage = secureStorage,
             config = config,
+            biometricManager = authManager,
         )
     }
 

--- a/tangem-sdk-android-demo/src/main/java/com/tangem/tangem_demo/ui/BaseFragment.kt
+++ b/tangem-sdk-android-demo/src/main/java/com/tangem/tangem_demo/ui/BaseFragment.kt
@@ -74,7 +74,7 @@ abstract class BaseFragment : Fragment() {
 
     private val userCodeRepository: UserCodeRepository by lazy {
         UserCodeRepository(
-            biometricManager = sdk.biometricManager,
+            biometricManager = sdk.biometricManager!!,
             secureStorage = sdk.secureStorage,
         )
     }

--- a/tangem-sdk-android/src/main/java/com/tangem/tangem_sdk_new/extensions/TangemSdk.kt
+++ b/tangem-sdk-android/src/main/java/com/tangem/tangem_sdk_new/extensions/TangemSdk.kt
@@ -24,10 +24,12 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun TangemSdk.init(activity: FragmentActivity, config: Config = Config()): TangemSdk {
+fun TangemSdk.Companion.init(
+    activity: ComponentActivity,
+    config: Config = Config(),
+): TangemSdk {
     val secureStorage = SecureStorage.create(activity)
     val nfcManager = TangemSdk.initNfcManager(activity)
-    val authManager = TangemSdk.initBiometricAuthManager(activity, secureStorage)
 
     val viewDelegate = DefaultSessionViewDelegate(nfcManager, nfcManager.reader, activity)
     viewDelegate.sdkConfig = config
@@ -35,45 +37,42 @@ fun TangemSdk.init(activity: FragmentActivity, config: Config = Config()): Tange
     return TangemSdk(
         reader = nfcManager.reader,
         viewDelegate = viewDelegate,
-        biometricManager = authManager,
         secureStorage = secureStorage,
         config = config,
     )
 }
 
-fun TangemSdk.customDelegate(
-    activity: FragmentActivity,
+fun TangemSdk.Companion.customDelegate(
+    activity: ComponentActivity,
     viewDelegate: SessionViewDelegate? = null,
     config: Config = Config(),
 ): TangemSdk {
     val secureStorage = SecureStorage.create(activity)
     val nfcManager = TangemSdk.initNfcManager(activity)
-    val authManager = TangemSdk.initBiometricAuthManager(activity, secureStorage)
 
-    val safeViewDelegate = viewDelegate
-        ?: DefaultSessionViewDelegate(nfcManager, nfcManager.reader, activity).apply {
-            this.sdkConfig = config
-        }
-
+    val safeViewDelegate = viewDelegate ?: DefaultSessionViewDelegate(nfcManager, nfcManager.reader, activity).apply {
+        this.sdkConfig = config
+    }
 
     return TangemSdk(
-        nfcManager.reader,
-        safeViewDelegate,
+        reader = nfcManager.reader,
+        viewDelegate = safeViewDelegate,
         secureStorage = secureStorage,
         config = config,
-        biometricManager = authManager,
     )
 }
 
-fun TangemSdk.initNfcManager(activity: ComponentActivity): NfcManager {
+fun TangemSdk.Companion.initNfcManager(
+    activity: ComponentActivity,
+): NfcManager {
     val nfcManager = NfcManager()
     nfcManager.setCurrentActivity(activity)
     activity.lifecycle.addObserver(NfcLifecycleObserver(nfcManager))
     return nfcManager
 }
 
-fun TangemSdk.createLogger(
-    formatter: LogFormat? = null
+fun TangemSdk.Companion.createLogger(
+    formatter: LogFormat? = null,
 ): TangemSdkLogger = object : TangemSdkLogger {
 
     val dateFormatter: DateFormat = SimpleDateFormat("HH:mm:ss:SSS", Locale.getDefault())
@@ -95,7 +94,8 @@ fun TangemSdk.createLogger(
         }
     }
 }
-fun TangemSdk.initBiometricAuthManager(
+
+fun TangemSdk.Companion.initBiometricAuthManager(
     activity: FragmentActivity,
     secureStorage: SecureStorage,
 ): BiometricManager {

--- a/tangem-sdk-core/src/main/java/com/tangem/crypto/CryptoUtils.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/crypto/CryptoUtils.kt
@@ -16,7 +16,13 @@ import javax.crypto.spec.SecretKeySpec
 
 object CryptoUtils {
 
+    var isInitialized = false
+        private set
+
     fun initCrypto() {
+        if (isInitialized) return
+        isInitialized = true
+
         Security.addProvider(BouncyCastleProvider())
         Security.addProvider(EdDSASecurityProvider())
     }
@@ -149,7 +155,6 @@ fun ByteArray.decrypt(key: ByteArray, usePkcs7: Boolean = true): ByteArray {
 fun ByteArray.pbkdf2Hash(salt: ByteArray, iterations: Int): ByteArray {
     return Pbkdf2().deriveKey(this, salt, iterations)
 }
-
 
 fun ByteArray.hmacSha512(input: ByteArray): ByteArray {
     val key = this

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/resetcode/ResetPinService.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/resetcode/ResetPinService.kt
@@ -1,12 +1,12 @@
 package com.tangem.operations.resetcode
 
 import com.tangem.Message
-import com.tangem.TangemSdk
 import com.tangem.common.CompletionResult
 import com.tangem.common.StringsLocator
 import com.tangem.common.UserCodeType
 import com.tangem.common.core.CompletionCallback
 import com.tangem.common.core.Config
+import com.tangem.common.core.SessionBuilder
 import com.tangem.common.core.TangemError
 import com.tangem.common.core.TangemSdkError
 import com.tangem.common.extensions.calculateSha256
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class ResetPinService(
+    private val sessionBuilder: SessionBuilder,
     private val stringsLocator: StringsLocator,
     private val config: Config
 ) {
@@ -103,7 +104,7 @@ class ResetPinService(
         }
 
         val command = GetResetPinTokenCommand()
-        TangemSdk.makeSession(
+        sessionBuilder.build(
             config = config,
             cardId = resetCardId,
             initialMessage = Message(
@@ -129,7 +130,7 @@ class ResetPinService(
             return
         }
         val command = SignResetPinTokenCommand(resetPinCard)
-        TangemSdk.makeSession(
+        sessionBuilder.build(
             config = config,
             initialMessage = Message(
                 header = stringsLocator.getString(
@@ -185,7 +186,7 @@ class ResetPinService(
 
 
         val command = ResetPinTask(confirmationCard, accessCodeUnwrapped, passcodeUnwrapped)
-        TangemSdk.makeSession(
+        sessionBuilder.build(
             config = config,
             cardId = resetPinCard.cardId,
             initialMessage = Message(


### PR DESCRIPTION
- Пришлось вывести  TangemSdk из синглтон состояния, т.к. для сторонних проектов\платформ нужна возможность создавать\уничтожать объект сдк по надобности.
