### PR TITLE
AND-7179 Design PreflightReadFilter

### DIFF
--- a/tangem-sdk-android-demo/src/main/java/com/tangem/demo/ui/BaseFragment.kt
+++ b/tangem-sdk-android-demo/src/main/java/com/tangem/demo/ui/BaseFragment.kt
@@ -52,6 +52,7 @@ import com.tangem.operations.files.FileToWrite
 import com.tangem.operations.files.FileVisibility
 import com.tangem.operations.issuerAndUserData.WriteIssuerExtraDataCommand
 import com.tangem.operations.personalization.entities.CardConfig
+import com.tangem.operations.preflightread.CardIdPreflightReadFilter
 import com.tangem.tangem_demo.R
 import kotlinx.android.synthetic.main.bottom_sheet_response_layout.*
 import kotlinx.coroutines.runBlocking
@@ -464,7 +465,11 @@ abstract class BaseFragment : Fragment() {
             rescan -> {
                 showToast("Need rescan the card after Create/Purge wallet")
                 post(delay) {
-                    val command = PreflightReadTask(PreflightReadMode.FullCardRead, card?.cardId)
+                    val command = PreflightReadTask(
+                        readMode = PreflightReadMode.FullCardRead,
+                        filter = card?.cardId?.let(::CardIdPreflightReadFilter),
+                    )
+
                     sdk.startSessionWithRunnable(command) {
                         postUi { setCard(it, false, callback = callback) }
                     }

--- a/tangem-sdk-core/src/main/java/com/tangem/common/core/CardSession.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/common/core/CardSession.kt
@@ -28,6 +28,7 @@ import com.tangem.crypto.pbkdf2Hash
 import com.tangem.operations.OpenSessionCommand
 import com.tangem.operations.PreflightReadMode
 import com.tangem.operations.PreflightReadTask
+import com.tangem.operations.preflightread.CardIdPreflightReadFilter
 import com.tangem.operations.read.ReadCommand
 import com.tangem.operations.resetcode.ResetCodesController
 import com.tangem.operations.resetcode.ResetPinService
@@ -305,12 +306,18 @@ class CardSession(
 
     private fun preflightCheck(onSessionStarted: SessionStartedCallback) {
         Log.session { "start preflight check" }
-        val preflightTask = PreflightReadTask(preflightReadMode, cardId)
+
+        val preflightTask = PreflightReadTask(
+            readMode = preflightReadMode,
+            filter = cardId?.let(::CardIdPreflightReadFilter),
+        )
+
         preflightTask.run(this) { result ->
             when (result) {
                 is CompletionResult.Success -> {
                     onSessionStarted(this, null)
                 }
+
                 is CompletionResult.Failure -> {
                     val wrongType = when (result.error) {
                         is TangemSdkError.WrongCardType -> WrongValueType.CardType

--- a/tangem-sdk-core/src/main/java/com/tangem/common/json/MoshiJsonConverter.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/common/json/MoshiJsonConverter.kt
@@ -21,6 +21,7 @@ import com.tangem.common.extensions.toHexString
 import com.tangem.crypto.hdWallet.BIP44
 import com.tangem.crypto.hdWallet.DerivationNode
 import com.tangem.crypto.hdWallet.DerivationPath
+import com.tangem.operations.PreflightReadFilterAdapter
 import com.tangem.operations.PreflightReadMode
 import com.tangem.operations.attestation.Attestation
 import com.tangem.operations.attestation.AttestationTask
@@ -124,6 +125,7 @@ class MoshiJsonConverter(adapters: List<Any> = listOf(), typedAdapters: Map<Clas
                 TangemSdkAdapter.BackupStatusAdapter(),
                 TangemSdkAdapter.DerivationPathAdapter(),
                 TangemSdkAdapter.DerivationNodeAdapter(),
+                PreflightReadFilterAdapter(),
             )
         }
 

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/PreflightReadFilterAdapter.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/PreflightReadFilterAdapter.kt
@@ -1,0 +1,36 @@
+package com.tangem.operations
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import com.tangem.common.json.MoshiJsonConverter
+import com.tangem.operations.preflightread.PreflightReadFilter
+
+internal class PreflightReadFilterAdapter : JsonAdapter<PreflightReadFilter>() {
+
+    private val moshi: Moshi by lazy { MoshiJsonConverter.default().moshi }
+
+    @FromJson
+    override fun fromJson(reader: JsonReader): PreflightReadFilter? {
+        if (reader.peek() == JsonReader.Token.NULL) {
+            reader.nextNull<Any>()
+            return null
+        }
+
+        val jsonAdapter = moshi.adapter<Any>(PreflightReadFilter::class.java)
+        return jsonAdapter.fromJson(reader) as? PreflightReadFilter
+    }
+
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: PreflightReadFilter?) {
+        if (value == null) {
+            writer.nullValue()
+        } else {
+            val jsonAdapter = moshi.adapter<Any>(PreflightReadFilter::class.java)
+            jsonAdapter.toJson(writer, value)
+        }
+    }
+}

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/PersonalizeCommand.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/personalization/PersonalizeCommand.kt
@@ -55,7 +55,7 @@ class PersonalizeCommand(
     override fun run(session: CardSession, callback: CompletionCallback<Card>) {
         Log.command(this)
         // We have to run preflight read ourselves to catch the notPersonalized error
-        val read = PreflightReadTask(PreflightReadMode.ReadCardOnly, null)
+        val read = PreflightReadTask(PreflightReadMode.ReadCardOnly)
         read.run(session) { result ->
             when (result) {
                 is CompletionResult.Success -> callback(CompletionResult.Failure(TangemSdkError.AlreadyPersonalized()))

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/preflightread/CardIdPreflightReadFilter.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/preflightread/CardIdPreflightReadFilter.kt
@@ -1,0 +1,20 @@
+package com.tangem.operations.preflightread
+
+import com.tangem.common.CardIdFormatter
+import com.tangem.common.card.Card
+import com.tangem.common.core.SessionEnvironment
+import com.tangem.common.core.TangemSdkError
+
+class CardIdPreflightReadFilter(private val expectedCardId: String) : PreflightReadFilter {
+
+    override fun onCardRead(card: Card, environment: SessionEnvironment) {
+        if (!expectedCardId.equals(card.cardId, ignoreCase = true)) {
+            val formatter = CardIdFormatter(style = environment.config.cardIdDisplayFormat)
+            val expectedCardIdFormatted = formatter.getFormattedCardId(expectedCardId)
+
+            throw TangemSdkError.WrongCardNumber(cardId = expectedCardIdFormatted ?: expectedCardId)
+        }
+    }
+
+    override fun onFullCardRead(card: Card, environment: SessionEnvironment) = Unit
+}

--- a/tangem-sdk-core/src/main/java/com/tangem/operations/preflightread/PreflightReadFilter.kt
+++ b/tangem-sdk-core/src/main/java/com/tangem/operations/preflightread/PreflightReadFilter.kt
@@ -1,0 +1,26 @@
+package com.tangem.operations.preflightread
+
+import com.tangem.common.card.Card
+import com.tangem.common.core.SessionEnvironment
+
+/** Use this filter to filter out cards on preflight read stage */
+interface PreflightReadFilter {
+
+    /**
+     * Method calls right after public information is read. User code is not required. If PreflightReadMode is set to
+     * ReadCardOnly or FullCardRead
+     *
+     * @param card        card that was read
+     * @param environment current environment
+     */
+    fun onCardRead(card: Card, environment: SessionEnvironment)
+
+    /**
+     * Method calls right after full card information is read. User code is required. If PreflightReadMode is set to
+     * FullCardRead
+     *
+     * @param card        card that was read
+     * @param environment current environment
+     */
+    fun onFullCardRead(card: Card, environment: SessionEnvironment)
+}

--- a/tangem-sdk-core/src/test/resources/jsonRpc/PreflightRead.json
+++ b/tangem-sdk-core/src/test/resources/jsonRpc/PreflightRead.json
@@ -4,8 +4,7 @@
     "id": 1,
     "method": "preflight_read",
     "params": {
-      "readMode": "fullCardRead",
-      "cardId": "BB03000000000004"
+      "readMode": "fullCardRead"
     }
   }
 }


### PR DESCRIPTION
Секретная разработка iOS, которая была скрыта от Android. Но после некоторых обманных махинаций мне удалось раскрыть тайный секрет ~~Крабсбургера~~ отфильтровки кард в PreflightReadTask.

Раньше PreflightReadTask по-умолчанию включал поведение, при котором отсканированные карты фильтровались по определенному cardId. Теперь мы можем передавать в PreflightReadTask определенный фильтр, например, CardIdPreflightReadFilter, которая уже сама реализует признак фильтрации.
Этот функционал позволит на стороне приложения реализовать фильтр по UserWalletId. Это поможет определять – является отсканенная карта частью комплекта или нет